### PR TITLE
Cba 267 session refresh update

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -961,11 +961,11 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 			session_timeout = 0;
 		}
 
-		//if ((tech_pvt->session_timeout = session_timeout)) {
-			tech_pvt->session_refresher = switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND ? nua_local_refresher : nua_remote_refresher;
-			if (sofia_test_pflag(tech_pvt->profile, PFLAG_UPDATE_REFRESHER) || switch_channel_var_true(tech_pvt->channel, "sip_update_refresher")) {
-				tech_pvt->update_refresher = 1;
-			}
+		tech_pvt->session_timeout = session_timeout;
+		tech_pvt->session_refresher = switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND ? nua_local_refresher : nua_remote_refresher;
+		if (sofia_test_pflag(tech_pvt->profile, PFLAG_UPDATE_REFRESHER) || switch_channel_var_true(tech_pvt->channel, "sip_update_refresher")) {
+			tech_pvt->update_refresher = 1;
+		}
 		//} else {
 		//	tech_pvt->session_refresher = nua_no_refresher;
 		//}

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -961,14 +961,14 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 			session_timeout = 0;
 		}
 
-		if ((tech_pvt->session_timeout = session_timeout)) {
+		//if ((tech_pvt->session_timeout = session_timeout)) {
 			tech_pvt->session_refresher = switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND ? nua_local_refresher : nua_remote_refresher;
 			if (sofia_test_pflag(tech_pvt->profile, PFLAG_UPDATE_REFRESHER) || switch_channel_var_true(tech_pvt->channel, "sip_update_refresher")) {
 				tech_pvt->update_refresher = 1;
 			}
-		} else {
-			tech_pvt->session_refresher = nua_no_refresher;
-		}
+		//} else {
+		//	tech_pvt->session_refresher = nua_no_refresher;
+		//}
 
 		if (sofia_use_soa(tech_pvt)) {
 			nua_respond(tech_pvt->nh, SIP_200_OK,

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1639,14 +1639,15 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		sofia_clear_flag(tech_pvt, TFLAG_ENABLE_SOA);
 	}
 
-	if ((tech_pvt->session_timeout = session_timeout)) {
-		tech_pvt->session_refresher = switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND ? nua_local_refresher : nua_remote_refresher;
-		if (sofia_test_pflag(tech_pvt->profile, PFLAG_UPDATE_REFRESHER) || switch_channel_var_true(tech_pvt->channel, "sip_update_refresher")) {
-			tech_pvt->update_refresher = 1;
-		}
-	} else {
-		tech_pvt->session_refresher = nua_no_refresher;
+
+	tech_pvt->session_timeout = session_timeout;
+	tech_pvt->session_refresher = switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND ? nua_local_refresher : nua_remote_refresher;
+	if (sofia_test_pflag(tech_pvt->profile, PFLAG_UPDATE_REFRESHER) || switch_channel_var_true(tech_pvt->channel, "sip_update_refresher")) {
+		tech_pvt->update_refresher = 1;
 	}
+	//} else {
+	//	tech_pvt->session_refresher = nua_no_refresher;
+	//}
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(tech_pvt->session), SWITCH_LOG_INFO, "%s sending invite call-id: %s\n",
 					  switch_channel_get_name(tech_pvt->channel), call_id);


### PR DESCRIPTION
This addresses Freeswitch behavior when _passively_ using session-timers.  By passively, we mean that FS is NOT requiring that session-timers be used for the dialog, but the other party IS requiring that they be used ( and that FS act as the refresher ).  

The issue we were facing was when FS was acting as the refresher, it would only use INVITE as the refresher method.  In a bridged context, the session-refresh INVITE would go out without SDP, and then Freeswitch would ACK the 200/SDP  without SDP, causing the other party to object to the lack of SDP.

FS dev had [introduced a new SIP Profile param](https://freeswitch.org/jira/browse/FS-10067) ( `<param name="update-refresher" value="true"/>` ) but this was having no effect on FS behavior when used in a passive context.  That is, the update-refresher would only be put to use if FS actively required session-timers rather, but would not use the update-refresher when accepting the requirement of the other party (passive).

This change addresses that.  When FS accepts an invite requiring the refresher=uas , or when  FS receives a response requiring that refresher=uac,  FS will appropriately use the update method for session refresh.




